### PR TITLE
LP-28928 fixed

### DIFF
--- a/python3/ltk/actions/init_action.py
+++ b/python3/ltk/actions/init_action.py
@@ -115,9 +115,6 @@ class InitAction():
             config_parser.set('main', 'access_token', access_token)
             config_parser.set('main', 'host', host)
             # config_parser.set('main', 'root_path', project_path)
-            logger.info('---------------------------')
-            logger.info('SELECT LINGOTEK COMMUNITY')
-            logger.info('---------------------------')
             # get community id
             community_info = self.api.get_communities_info()
             if not community_info:
@@ -131,6 +128,9 @@ class InitAction():
             if len(community_info) == 0:
                 raise exceptions.ResourceNotFound('You are not part of any communities in Lingotek Cloud')
             if len(community_info) > 1:
+                logger.info('---------------------------')
+                logger.info('SELECT LINGOTEK COMMUNITY')
+                logger.info('---------------------------')
                 community_id, community_name = self.display_choice('community', community_info)
             else:
                 for id in community_info:
@@ -429,7 +429,7 @@ class InitAction():
                 logger.error("Error on init: "+str(e))
 
     def create_new_project(self, folder_name, community_id, workflow_id):
-        prompt_message = "Please enter a new Lingotek project name: %s" % folder_name + chr(8) * len(folder_name)
+        prompt_message = "Please enter a new Lingotek project name [%s]: " % folder_name
         try:
             # Python 2
             # project_name = raw_input(prompt_message)

--- a/python3/ltk/commands.py
+++ b/python3/ltk/commands.py
@@ -375,7 +375,7 @@ def download(auto_format, locales, locale_ext, no_ext, xliff, file_names):
         return
 
 
-@ltk.command()
+@ltk.command(short_help='Pulls translations for all added documents for all locales or by specified locales')
 @click.option('-a', '--auto_format', flag_value=True, help='Flag to auto apply formatting during download')
 @click.option('-e', '--locale_ext', flag_value=True, help="Specifies to add the name of the locale as an extension to the file name (ex: doc1.fr_FR.docx). This is the default unless the clone download option is active.")
 @click.option('-n', '--no_ext', flag_value=True, help="Specifies to not add the name of the locale as an extension to the file name. This is the default if the clone download option is active.")


### PR DESCRIPTION
made a few UI improvements:
-doesn't display the SELECT A COMMUNITY header when there is only one community and it is autoselected
-shows default new project name in front of the colon instead of after the colon
-doesn't truncate the command info for pull when ltk -h is run