### PR TITLE
LP-29084 done

### DIFF
--- a/python2/ltk/actions/config_action.py
+++ b/python2/ltk/actions/config_action.py
@@ -238,7 +238,7 @@ class ConfigAction(Action):
 
     def set_download_folder(self, download_folder):
         if download_folder == '--none':
-            if self.download_dir == None or self.download_dir == "" or self.download_dir == "null":
+            if self.download_dir == "":
                 pass
             else:
                 new_download_option = 'same'

--- a/python2/ltk/actions/download_action.py
+++ b/python2/ltk/actions/download_action.py
@@ -51,7 +51,7 @@ class DownloadAction(Action):
                         return
                     self._clone_download(locale_code)
                 elif 'folder' in self.download_option:
-                    locale_code = locale_code.replace("_","-")
+                    locale_code = locale_code.replace("-","_")#change to be _ to - to be consistent with the other cases.  Currently the default is xx-XX in all cases except this one (clone off, download folder specified) 
                     if locale_code in self.locale_folders:
                         if self.locale_folders[locale_code] == 'null':
                             logger.warning("Download failed: folder not specified for "+locale_code)

--- a/python2/ltk/actions/download_action.py
+++ b/python2/ltk/actions/download_action.py
@@ -51,7 +51,7 @@ class DownloadAction(Action):
                         return
                     self._clone_download(locale_code)
                 elif 'folder' in self.download_option:
-                    locale_code = locale_code.replace("-","_")
+                    locale_code = locale_code.replace("_","-")
                     if locale_code in self.locale_folders:
                         if self.locale_folders[locale_code] == 'null':
                             logger.warning("Download failed: folder not specified for "+locale_code)
@@ -281,7 +281,7 @@ class DownloadAction(Action):
                 temp_zip.write(chunk)
             temp_zip.seek(0)
             zip_ref = zipfile.ZipFile(temp_zip)
-            with open(self.download_path, 'wb') as fh:
-                zip_path = locale_code + "/" + self.append_ext_to_file(locale_code, base_name, True)
-                fh.write(zip_ref.open(zip_path).read())
+            with open(self.download_path, 'w+b') as fh:
+                filenames = zip_ref.namelist()
+                fh.write(zip_ref.open(filenames[0]).read())
             zip_ref.close()

--- a/python3/ltk/actions/config_action.py
+++ b/python3/ltk/actions/config_action.py
@@ -238,7 +238,7 @@ class ConfigAction(Action):
 
     def set_download_folder(self, download_folder):
         if download_folder == '--none':
-            if self.download_dir == None or self.download_dir == "" or self.download_dir == "null":
+            if self.download_dir == "":
                 pass
             else:
                 new_download_option = 'same'

--- a/python3/ltk/actions/download_action.py
+++ b/python3/ltk/actions/download_action.py
@@ -51,7 +51,7 @@ class DownloadAction(Action):
                         return
                     self._clone_download(locale_code)
                 elif 'folder' in self.download_option:
-                    locale_code = locale_code.replace("_","-")
+                    locale_code = locale_code.replace("-","_")#change to be _ to - to be consistent with the other cases.  Currently the default is xx-XX in all cases except this one (clone off, download folder specified) 
                     if locale_code in self.locale_folders:
                         if self.locale_folders[locale_code] == 'null':
                             logger.warning("Download failed: folder not specified for "+locale_code)

--- a/python3/ltk/actions/download_action.py
+++ b/python3/ltk/actions/download_action.py
@@ -51,7 +51,7 @@ class DownloadAction(Action):
                         return
                     self._clone_download(locale_code)
                 elif 'folder' in self.download_option:
-                    locale_code = locale_code.replace("-","_")
+                    locale_code = locale_code.replace("_","-")
                     if locale_code in self.locale_folders:
                         if self.locale_folders[locale_code] == 'null':
                             logger.warning("Download failed: folder not specified for "+locale_code)
@@ -281,7 +281,7 @@ class DownloadAction(Action):
                 temp_zip.write(chunk)
             temp_zip.seek(0)
             zip_ref = zipfile.ZipFile(temp_zip)
-            with open(self.download_path, 'wb') as fh:
-                zip_path = locale_code + "/" + self.append_ext_to_file(locale_code, base_name, True)
-                fh.write(zip_ref.open(zip_path).read())
+            with open(self.download_path, 'w+b') as fh:
+                filenames = zip_ref.namelist()
+                fh.write(zip_ref.open(filenames[0]).read())
             zip_ref.close()


### PR DESCRIPTION
- enabled finalized file downloading and unzipping with xx-XX and xx_XX locale formats
- ensured files already in one format used that format.
NOTE: Did not fix inconsistency with default format in different cases with clone and download folder options.  That will be evaluated on a later ticket.