### PR TITLE
LP-25396

### DIFF
--- a/python2/ltk/watch.py
+++ b/python2/ltk/watch.py
@@ -437,8 +437,8 @@ class WatchAction(Action):
             observer.schedule(self.handler, path=watch_path, recursive=True)
             try:
                 observer.start()
-            except:
-                logger.warning("Make sure a folder has been added first!")
+            except OSError as e:
+                logger.warning("Watching too many items, please be more specific by using ltk add on the files and folders that should be watched")
                 return
             self.observers.append(observer)
         queue_timeout = 3

--- a/python2/ltk/watch.py
+++ b/python2/ltk/watch.py
@@ -435,7 +435,11 @@ class WatchAction(Action):
         for watch_path in watch_paths:
             observer = Observer()
             observer.schedule(self.handler, path=watch_path, recursive=True)
-            observer.start()
+            try:
+                observer.start()
+            except:
+                logger.warning("Make sure a folder has been added first!")
+                return
             self.observers.append(observer)
         queue_timeout = 3
         # start_time = time.clock()

--- a/python3/ltk/watch.py
+++ b/python3/ltk/watch.py
@@ -437,8 +437,8 @@ class WatchAction(Action):
             observer.schedule(self.handler, path=watch_path, recursive=True)
             try:
                 observer.start()
-            except:
-                logger.warning("Make sure a folder has been added first!")
+            except OSError as e:
+                logger.warning("Watching too many items, please be more specific by using ltk add on the files and folders that should be watched")
                 return
             self.observers.append(observer)
         queue_timeout = 3

--- a/python3/ltk/watch.py
+++ b/python3/ltk/watch.py
@@ -435,7 +435,11 @@ class WatchAction(Action):
         for watch_path in watch_paths:
             observer = Observer()
             observer.schedule(self.handler, path=watch_path, recursive=True)
-            observer.start()
+            try:
+                observer.start()
+            except:
+                logger.warning("Make sure a folder has been added first!")
+                return
             self.observers.append(observer)
         queue_timeout = 3
         # start_time = time.clock()


### PR DESCRIPTION
Issue:
 Running ltk watch without adding a folder first is broken
Fix:
Throw exception which prints a warning when this happens in both python 2 and 3